### PR TITLE
fix: include static assets in hatchling build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,11 @@ dev = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["auditorium"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/auditorium",
+]


### PR DESCRIPTION
Problem: > The current Hatchling configuration only bundles .py files. As a result, the static/ directory (containing index.html) is missing from the installed package in site-packages, leading to a FileNotFoundError when running the server.

Solution:
Updated pyproject.toml to explicitly include the auditorium package and its subdirectories in the wheel and sdist targets.

Changes:

    Added [tool.hatch.build.targets.wheel] configuration.

    Added [tool.hatch.build.targets.sdist] configuration.